### PR TITLE
alex/ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,18 +13,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest] # [macOS-latest, windows-latest] do not come with docker :(
-        cabal: ["3.2"]
+        cabal: ["3.8.1.0"]
         ghc:
-          - "8.8.3"
-          - "8.10.1"
-          - "8.10.2"
-        exclude:
-          - os: macOS-latest
-            ghc: 8.8.3
-          - os: windows-latest
-            ghc: 8.8.3
-          - os: windows-latest
-            ghc: 8.6.5
+          - "9.2.4"
+          - "9.4.2"
 
     steps:
     - uses: actions/checkout@v2

--- a/cabal.project
+++ b/cabal.project
@@ -1,3 +1,3 @@
 packages: .
 
-index-state: 2021-03-28T17:36:17Z
+index-state: 2022-10-11T10:58:41Z

--- a/src/TestContainers.hs
+++ b/src/TestContainers.hs
@@ -1,121 +1,98 @@
 -- |
 -- This module shall be used as entrypoint to the testcontainers library. It exports
 -- all the necessary types and functions for most common use-cases.
---
 module TestContainers
-  (
-
-    -- * Docker images
-
-    M.ImageTag
-
-  , M.Image
-  , M.imageTag
+  ( -- * Docker images
+    M.ImageTag,
+    M.Image,
+    M.imageTag,
 
     -- * Referring to Docker images
+    M.ToImage,
+    M.fromTag,
+    M.fromBuildContext,
+    M.build,
 
-  , M.ToImage
-  , M.fromTag
-  , M.fromBuildContext
-  , M.build
-
-  -- * @docker run@ parameters
-
-  , M.ContainerRequest
-  , M.containerRequest
-
-  , M.setName
-  , M.setFixedName
-  , M.setSuffixedName
-  , M.setRandomName
-  , M.setCmd
-  , M.setVolumeMounts
-  , M.setRm
-  , M.setEnv
-  , M.setNetwork
-  , M.setLink
-  , M.setExpose
-  , M.setWaitingFor
+    -- * @docker run@ parameters
+    M.ContainerRequest,
+    M.containerRequest,
+    M.setName,
+    M.setFixedName,
+    M.setSuffixedName,
+    M.setRandomName,
+    M.setCmd,
+    M.setVolumeMounts,
+    M.setRm,
+    M.setEnv,
+    M.setNetwork,
+    M.setLink,
+    M.setExpose,
+    M.setWaitingFor,
 
     -- * Running Docker containers (@docker run@)
-
-  , M.Container
-  , M.containerGateway
-  , M.containerIp
-  , M.containerPort
-  , M.containerReleaseKey
-  , M.containerImage
-
-  , M.run
+    M.Container,
+    M.containerGateway,
+    M.containerIp,
+    M.containerPort,
+    M.containerReleaseKey,
+    M.containerImage,
+    M.run,
 
     -- * Inspecting Docker containers
-
-  , M.InspectOutput
-  , M.inspect
+    M.InspectOutput,
+    M.inspect,
 
     -- * Docker container lifecycle
-
-  , M.stop
-  , M.kill
-  , M.rm
-  , M.withLogs
+    M.stop,
+    M.kill,
+    M.rm,
+    M.withLogs,
 
     -- * Readiness checks
-
-  , M.WaitUntilReady
+    M.WaitUntilReady,
 
     -- ** Timeout for readiness checks
-
-  , M.waitUntilTimeout
+    M.waitUntilTimeout,
 
     -- ** Waiting on particular log lines
-
-  , M.Pipe(..)
-  , M.waitWithLogs
-  , M.waitForLogLine
+    M.Pipe (..),
+    M.waitWithLogs,
+    M.waitForLogLine,
 
     -- ** Wait until connection can be established
-
-  , M.waitUntilMappedPortReachable
+    M.waitUntilMappedPortReachable,
 
     -- * Monad
-
-  , M.MonadDocker
+    M.MonadDocker,
+    M.TestContainer,
 
     -- * Configuration
-
-  , Config(..)
-  , defaultDockerConfig
-  , determineConfig
-
-    -- *
-
-  , Tracer
-  , Trace(..)
-  , newTracer
+    Config (..),
+    defaultDockerConfig,
+    determineConfig,
+    Tracer,
+    Trace (..),
+    newTracer,
 
     -- * Exceptions
-
-  , M.DockerException(..)
-  , M.TimeoutException(..)
-  , M.UnexpectedEndOfPipe(..)
+    M.DockerException (..),
+    M.TimeoutException (..),
+    M.UnexpectedEndOfPipe (..),
 
     -- * Misc. Docker functions
-
-  , dockerHostOs
-  , isDockerOnLinux
+    dockerHostOs,
+    isDockerOnLinux,
 
     -- * Predefined Docker images
-
-  , M.redis
-  , M.mongo
+    M.redis,
+    M.mongo,
 
     -- * Reexports
+    ResIO,
+    runResourceT,
+    (&),
+  )
+where
 
-  , ResIO
-  , runResourceT
-  , (&)
-  ) where
-
-import           TestContainers.Docker as M
-import           TestContainers.Image  as M
+import TestContainers.Docker as M
+import TestContainers.Image as M

--- a/src/TestContainers/AesonCompat.hs
+++ b/src/TestContainers/AesonCompat.hs
@@ -1,13 +1,15 @@
 {-# LANGUAGE CPP #-}
-module TestContainers.AesonCompat (
-    toKey
-) where 
+
+module TestContainers.AesonCompat
+  ( toKey,
+  )
+where
 
 #if MIN_VERSION_aeson(2,0,0)
 import qualified Data.Aeson.Key as Key
 #else
 #endif
-import qualified Data.Text                  as T
+import qualified Data.Text as T
 
 #if MIN_VERSION_aeson(2,0,0)
 type Key = Key.Key

--- a/src/TestContainers/AesonCompat.hs
+++ b/src/TestContainers/AesonCompat.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE CPP #-}
+module TestContainers.AesonCompat (
+    toKey
+) where 
+
+#if MIN_VERSION_aeson(2,0,0)
+import qualified Data.Aeson.Key as Key
+#else
+#endif
+import qualified Data.Text                  as T
+
+#if MIN_VERSION_aeson(2,0,0)
+type Key = Key.Key
+#else
+type Key = T.Text
+#endif
+
+toKey :: T.Text -> Key
+#if MIN_VERSION_aeson(2,0,0)
+toKey = Key.fromText
+#else
+toKey = id
+#endif

--- a/src/TestContainers/Docker.hs
+++ b/src/TestContainers/Docker.hs
@@ -1,436 +1,319 @@
-{-# LANGUAGE BangPatterns               #-}
-{-# LANGUAGE ConstraintKinds            #-}
-{-# LANGUAGE DerivingStrategies         #-}
-{-# LANGUAGE DuplicateRecordFields      #-}
-{-# LANGUAGE FlexibleContexts           #-}
-{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE NamedFieldPuns             #-}
-{-# LANGUAGE OverloadedStrings          #-}
-{-# LANGUAGE PatternSynonyms            #-}
-{-# LANGUAGE RankNTypes                 #-}
-{-# LANGUAGE ScopedTypeVariables        #-}
-{-# LANGUAGE StandaloneDeriving         #-}
-{-# LANGUAGE UndecidableInstances       #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE UndecidableInstances #-}
+
 module TestContainers.Docker
-  (
-    MonadDocker
+  ( MonadDocker,
+    TestContainer,
 
-  -- * Configuration
+    -- * Configuration
+    Config (..),
+    defaultDockerConfig,
+    determineConfig,
 
-  , Config(..)
-  , defaultDockerConfig
-  , determineConfig
+    -- * Exeuction tracing
+    Tracer,
+    Trace (..),
+    newTracer,
+    withTrace,
 
-  -- * Exeuction tracing
+    -- * Docker image
+    ImageTag,
+    Image,
+    imageTag,
 
-  , Tracer
-  , Trace(..)
-  , newTracer
-  , withTrace
+    -- * Docker container
+    ContainerId,
+    Container,
+    containerId,
+    containerImage,
+    containerGateway,
+    containerIp,
+    containerPort,
+    containerReleaseKey,
 
-  -- * Docker image
+    -- * Referring to images
+    ToImage,
+    fromTag,
+    fromBuildContext,
+    fromDockerfile,
+    build,
 
-  , ImageTag
+    -- * Exceptions
+    DockerException (..),
 
-  , Image
-  , imageTag
+    -- * Running containers
+    ContainerRequest,
+    containerRequest,
+    setName,
+    setFixedName,
+    setSuffixedName,
+    setRandomName,
+    setCmd,
+    setVolumeMounts,
+    setRm,
+    setEnv,
+    setNetwork,
+    setLink,
+    setExpose,
+    setWaitingFor,
+    run,
 
-  -- * Docker container
+    -- * Managing the container lifecycle
+    InspectOutput,
+    inspect,
+    stop,
+    kill,
+    rm,
+    withLogs,
 
-  , ContainerId
-  , Container
+    -- * Wait for containers to become ready
+    WaitUntilReady,
+    waitUntilReady,
 
-  , containerId
-  , containerImage
-  , containerGateway
-  , containerIp
-  , containerPort
-  , containerReleaseKey
+    -- * Only block for defined amounts of time
+    TimeoutException (..),
+    waitUntilTimeout,
 
-  -- * Referring to images
+    -- * Wait until a specific pattern appears in the logs
+    waitWithLogs,
+    UnexpectedEndOfPipe (..),
+    Pipe (..),
+    waitForLogLine,
 
-  , ToImage
+    -- * Misc. Docker functions
+    dockerHostOs,
+    isDockerOnLinux,
 
-  , fromTag
-  , fromBuildContext
-  , fromDockerfile
+    -- * Wait until a socket is reachable
+    waitUntilMappedPortReachable,
 
-  , build
+    -- * Reexports for convenience
+    ResIO,
+    runResourceT,
+    (&),
+  )
+where
 
-  -- * Exceptions
-
-  , DockerException(..)
-
-  -- * Running containers
-
-  , ContainerRequest
-  , containerRequest
-  , setName
-  , setFixedName
-  , setSuffixedName
-  , setRandomName
-  , setCmd
-  , setVolumeMounts
-  , setRm
-  , setEnv
-  , setNetwork
-  , setLink
-  , setExpose
-  , setWaitingFor
-  , run
-
-  -- * Managing the container lifecycle
-
-  , InspectOutput
-  , inspect
-
-  , stop
-  , kill
-  , rm
-  , withLogs
-
-  -- * Wait for containers to become ready
-  , WaitUntilReady
-  , waitUntilReady
-
-  -- * Only block for defined amounts of time
-  , TimeoutException(..)
-  , waitUntilTimeout
-
-  -- * Wait until a specific pattern appears in the logs
-  , waitWithLogs
-  , UnexpectedEndOfPipe(..)
-  , Pipe(..)
-  , waitForLogLine
-
-  -- * Misc. Docker functions
-
-  , dockerHostOs
-  , isDockerOnLinux
-
-  -- * Wait until a socket is reachable
-  , waitUntilMappedPortReachable
-
-  -- * Reexports for convenience
-  , ResIO
-  , runResourceT
-
-  , (&)
-  ) where
-
-import           Control.Applicative          ((<|>))
-import           Control.Concurrent           (threadDelay)
-import           Control.Exception            (IOException, throw)
-import           Control.Monad                (replicateM)
-import           Control.Monad.Catch          (Exception, MonadCatch, MonadMask,
-                                               MonadThrow, bracket, throwM, try)
-import           Control.Monad.Fix            (mfix)
-import           Control.Monad.IO.Class       (MonadIO (liftIO))
-import           Control.Monad.IO.Unlift      (MonadUnliftIO (withRunInIO))
-import           Control.Monad.Reader         (MonadReader (..), runReaderT)
-import           Control.Monad.Trans.Resource (MonadResource (liftResourceT),
-                                               ReleaseKey, ResIO, register,
-                                               runResourceT)
-import           Data.Aeson                   (Value, decode')
-import qualified Data.Aeson.Optics            as Optics
-import qualified Data.ByteString.Lazy.Char8   as LazyByteString
-import           Data.Foldable                (traverse_)
-import           Data.Function                ((&))
-import           Data.List                    (find)
-import           Data.Text                    (Text, pack, strip, unpack)
-import           Data.Text.Encoding.Error     (lenientDecode)
-import qualified Data.Text.Lazy               as LazyText
-import qualified Data.Text.Lazy.Encoding      as LazyText
-import           GHC.Stack                    (withFrozenCallStack)
-import qualified Network.Socket               as Socket
-import           Optics.Fold                  (pre)
-import           Optics.Operators             ((^?))
-import           Optics.Optic                 ((%))
-import           Prelude                      hiding (error, id)
+import Control.Applicative ((<|>))
+import Control.Concurrent (threadDelay)
+import Control.Exception (IOException, throw)
+import Control.Monad (replicateM)
+import Control.Monad.Catch
+  ( Exception,
+    MonadThrow,
+    bracket,
+    throwM,
+    try,
+  )
+import Control.Monad.Fix (mfix)
+import Control.Monad.IO.Class (MonadIO (liftIO))
+import Control.Monad.IO.Unlift (MonadUnliftIO (withRunInIO))
+import Control.Monad.Reader (ask)
+import Control.Monad.Trans.Resource
+  ( MonadResource (liftResourceT),
+    ReleaseKey,
+    ResIO,
+    register,
+    runResourceT,
+  )
+import Data.Aeson (Value, decode')
+import qualified Data.Aeson.Optics as Optics
+import qualified Data.ByteString.Lazy.Char8 as LazyByteString
+import Data.Foldable (traverse_)
+import Data.Function ((&))
+import Data.List (find)
+import Data.Text (Text, pack, strip, unpack)
+import Data.Text.Encoding.Error (lenientDecode)
+import qualified Data.Text.Lazy as LazyText
+import qualified Data.Text.Lazy.Encoding as LazyText
+import GHC.Stack (withFrozenCallStack)
+import qualified Network.Socket as Socket
+import Optics.Fold (pre)
+import Optics.Operators ((^?))
+import Optics.Optic ((%))
+import System.Directory (doesFileExist)
+import System.Exit (ExitCode (..))
+import System.IO (Handle, hClose)
+import System.IO.Unsafe (unsafePerformIO)
+import qualified System.Process as Process
+import qualified System.Random as Random
+import System.Timeout (timeout)
+import TestContainers.AesonCompat (toKey)
+import TestContainers.Monad
+  ( Config (..),
+    MonadDocker,
+    TestContainer,
+    defaultDockerConfig,
+    determineConfig,
+    runTestContainer,
+  )
+import TestContainers.Tracer (Trace (..), Tracer, newTracer, withTrace)
+import Prelude hiding (error, id)
 import qualified Prelude
-import           System.Directory             (doesFileExist)
-import           System.Exit                  (ExitCode (..))
-import qualified System.Random                as Random
-import           System.IO                    (Handle, hClose)
-import           System.IO.Unsafe             (unsafePerformIO)
-import qualified System.Process               as Process
-import           System.Timeout               (timeout)
-import           TestContainers.AesonCompat   (toKey)
-
--- | Type representing various events during testcontainer execution.
-data Trace
-  -- | The low-level invocation of @docker@ command
-  --
-  -- @
-  --   TraceDockerInvocation args stdin exitcode
-  -- @
-  = TraceDockerInvocation [Text] Text ExitCode -- docker [args] [stdin]
-  -- | Line written to STDOUT by a Docker process.
-  | TraceDockerStdout Text
-  -- | Line written to STDERR by a Docker process.
-  | TraceDockerStderr Text
-  -- | Waiting for a container to become ready. Attached with the
-  -- timeout to wait (in seconds).
-  | TraceWaitUntilReady (Maybe Int)
-  -- | Opening socket
-  | TraceOpenSocket Text Int (Maybe IOException)
-
-
-deriving stock instance Eq Trace
-deriving stock instance Show Trace
-
-
--- | Traces execution within testcontainers library.
-newtype Tracer = Tracer { unTracer :: Trace -> IO () }
-
-
-deriving newtype instance Semigroup Tracer
-deriving newtype instance Monoid Tracer
-
-
--- | Construct a new `Tracer` from a tracing function.
-newTracer
-  :: (Trace -> IO ())
-  -> Tracer
-newTracer action = Tracer
-  {
-    unTracer = action
-  }
-
-
-withTrace :: MonadIO m => Tracer -> Trace -> m ()
-withTrace tracer trace =
-  liftIO $ unTracer tracer trace
-{-# INLINE withTrace #-}
-
-
--- | Configuration for defaulting behavior.
---
--- @since 0.2.0.0
---
-data Config = Config
-  {
-    -- | The number of seconds to maximally wait for a container to
-    -- become ready. Default is `Just 60`.
-    --
-    -- @Nothing@ <=> waits indefinitely.
-    configDefaultWaitTimeout :: Maybe Int
-    -- | Traces execution inside testcontainers library.
-  , configTracer             :: Tracer
-  }
-
-
--- | Default configuration.
---
--- @since 0.2.0.0
---
-defaultDockerConfig :: Config
-defaultDockerConfig = Config
-  {
-    configDefaultWaitTimeout = Just 60
-  , configTracer = mempty
-  }
-
-
--- | Autoselect the default configuration depending on wether you use Docker For
--- Mac or not.
-determineConfig :: IO Config
-determineConfig =
-  pure defaultDockerConfig
-
 
 -- | Failing to interact with Docker results in this exception
 -- being thrown.
 --
 -- @since 0.1.0.0
---
 data DockerException
   = DockerException
-    {
-      -- | Exit code of the underlying Docker process.
-      exitCode :: ExitCode
-      -- | Arguments that were passed to Docker.
-    , args     :: [Text]
-      -- | Docker's STDERR output.
-    , stderr   :: Text
-    }
-  | InspectUnknownContainerId     { id :: ContainerId }
-  | InspectOutputInvalidJSON      { id :: ContainerId }
-  | InspectOutputMissingNetwork   { id :: ContainerId }
-  | InspectOutputUnexpected       { id :: ContainerId }
+      { -- | Exit code of the underlying Docker process.
+        exitCode :: ExitCode,
+        -- | Arguments that were passed to Docker.
+        args :: [Text],
+        -- | Docker's STDERR output.
+        stderr :: Text
+      }
+  | InspectUnknownContainerId {id :: ContainerId}
+  | InspectOutputInvalidJSON {id :: ContainerId}
+  | InspectOutputMissingNetwork {id :: ContainerId}
+  | InspectOutputUnexpected {id :: ContainerId}
   | UnknownPortMapping
-    {
-      -- | Id of the `Container` that we tried to lookup the
-      -- port mapping.
-      id   :: ContainerId
-      -- | Textual representation of port mapping we were
-      -- trying to look up.
-    , port :: Text
-    }
+      { -- | Id of the `Container` that we tried to lookup the
+        -- port mapping.
+        id :: ContainerId,
+        -- | Textual representation of port mapping we were
+        -- trying to look up.
+        port :: Text
+      }
   deriving (Eq, Show)
 
-
 instance Exception DockerException
-
-
--- | Docker related functionality is parameterized over this `Monad`.
---
--- @since 0.1.0.0
---
-type MonadDocker m =
-  (MonadIO m, MonadMask m, MonadThrow m, MonadCatch m, MonadResource m, MonadReader Config m)
-
 
 -- | Parameters for a running a Docker container.
 --
 -- @since 0.1.0.0
---
 data ContainerRequest = ContainerRequest
-  {
-    toImage      :: ToImage
-  , cmd          :: Maybe [Text]
-  , env          :: [(Text, Text)]
-  , exposedPorts :: [Int]
-  , volumeMounts :: [(Text, Text)]
-  , network      :: Maybe Text
-  , links        :: [ContainerId]
-  , naming       :: NamingStrategy
-  , rmOnExit     :: Bool
-  , readiness    :: Maybe WaitUntilReady
+  { toImage :: ToImage,
+    cmd :: Maybe [Text],
+    env :: [(Text, Text)],
+    exposedPorts :: [Int],
+    volumeMounts :: [(Text, Text)],
+    network :: Maybe Text,
+    links :: [ContainerId],
+    naming :: NamingStrategy,
+    rmOnExit :: Bool,
+    readiness :: Maybe WaitUntilReady
   }
-
 
 -- | Parameters for a naming a Docker container.
 --
 -- @since 0.4.0.0
---
 data NamingStrategy
   = RandomName
   | FixedName Text
   | SuffixedName Text
 
-
 -- | Default `ContainerRequest`. Used as base for every Docker container.
 --
 -- @since 0.1.0.0
---
 containerRequest :: ToImage -> ContainerRequest
-containerRequest image = ContainerRequest
-  {
-    toImage      = image
-  , naming       = RandomName
-  , cmd          = Nothing
-  , env          = []
-  , exposedPorts = []
-  , volumeMounts = []
-  , network      = Nothing
-  , links        = []
-  , rmOnExit     = True
-  , readiness    = Nothing
-  }
-
+containerRequest image =
+  ContainerRequest
+    { toImage = image,
+      naming = RandomName,
+      cmd = Nothing,
+      env = [],
+      exposedPorts = [],
+      volumeMounts = [],
+      network = Nothing,
+      links = [],
+      rmOnExit = True,
+      readiness = Nothing
+    }
 
 -- | Set the name of a Docker container. This is equivalent to invoking @docker run@
 -- with the @--name@ parameter.
 --
 -- @since 0.1.0.0
---
 setName :: Text -> ContainerRequest -> ContainerRequest
 setName = setFixedName
 {-# DEPRECATED setName "See setFixedName" #-}
-
 
 -- | Set the name of a Docker container. This is equivalent to invoking @docker run@
 -- with the @--name@ parameter.
 --
 -- @since 0.4.0.0
---
 setFixedName :: Text -> ContainerRequest -> ContainerRequest
 setFixedName newName req =
   -- TODO error on empty Text
-  req { naming = FixedName newName }
-
+  req {naming = FixedName newName}
 
 -- | Set the name randomly given of a Docker container. This is equivalent to omitting
 --  the @--name@ parameter calling @docker run@.
 --
 -- @since 0.4.0.0
---
 setRandomName :: ContainerRequest -> ContainerRequest
 setRandomName req =
   -- TODO error on empty Text
-  req { naming = RandomName }
-
+  req {naming = RandomName}
 
 -- | Set the name randomly suffixed of a Docker container. This is equivalent to invoking
 -- @docker run@ with the @--name@ parameter.
 --
 -- @since 0.4.0.0
---
 setSuffixedName :: Text -> ContainerRequest -> ContainerRequest
 setSuffixedName preffix req =
   -- TODO error on empty Text
-  req { naming = SuffixedName preffix }
-
+  req {naming = SuffixedName preffix}
 
 -- | The command to execute inside the Docker container. This is the equivalent
 -- of passing the command on the @docker run@ invocation.
 --
 -- @since 0.1.0.0
---
 setCmd :: [Text] -> ContainerRequest -> ContainerRequest
 setCmd newCmd req =
-  req { cmd = Just newCmd }
-
+  req {cmd = Just newCmd}
 
 -- | The volume mounts to link to Docker container. This is the equivalent
 -- of passing the command on the @docker run -v@ invocation.
---
---
 setVolumeMounts :: [(Text, Text)] -> ContainerRequest -> ContainerRequest
 setVolumeMounts newVolumeMounts req =
-  req { volumeMounts = newVolumeMounts }
+  req {volumeMounts = newVolumeMounts}
 
 -- | Wether to remove the container once exited. This is equivalent to passing
 -- @--rm@ to @docker run@. (default is `True`).
 --
 -- @since 0.1.0.0
---
 setRm :: Bool -> ContainerRequest -> ContainerRequest
 setRm newRm req =
-  req { rmOnExit = newRm }
-
+  req {rmOnExit = newRm}
 
 -- | Set the environment for the container. This is equivalent to passing @--env key=value@
 -- to @docker run@.
 --
 -- @since 0.1.0.0
---
 setEnv :: [(Text, Text)] -> ContainerRequest -> ContainerRequest
 setEnv newEnv req =
-  req { env = newEnv }
-
+  req {env = newEnv}
 
 -- | Set the network the container will connect to. This is equivalent to passing
 -- @--network network_name@ to @docker run@.
 --
 -- @since 0.4.0.0
---
 setNetwork :: Text -> ContainerRequest -> ContainerRequest
 setNetwork networkName req =
-  req { network = Just networkName }
-
+  req {network = Just networkName}
 
 -- | Set link on the container. This is equivalent to passing @--link other_container@
 -- to @docker run@.
 --
 -- @since 0.1.0.0
---
 setLink :: [ContainerId] -> ContainerRequest -> ContainerRequest
 setLink newLink req =
-  req { links = newLink }
-
+  req {links = newLink}
 
 -- | Set exposed ports on the container. This is equivalent to setting @--publish $PORT@ to
 -- @docker run@. Docker assigns a random port for the host port. You will have to use `containerIp`
@@ -443,48 +326,40 @@ setLink newLink req =
 -- @
 --
 -- @since 0.1.0.0
---
 setExpose :: [Int] -> ContainerRequest -> ContainerRequest
 setExpose newExpose req =
-  req { exposedPorts = newExpose }
-
+  req {exposedPorts = newExpose}
 
 -- | Set the waiting strategy on the container. Depending on a Docker container
 -- it can take some time until the provided service is ready. You will want to
 -- use to `setWaitingFor` to block until the container is ready to use.
 --
 -- @since 0.1.0.0
---
 setWaitingFor :: WaitUntilReady -> ContainerRequest -> ContainerRequest
 setWaitingFor newWaitingFor req =
-  req { readiness = Just newWaitingFor }
-
+  req {readiness = Just newWaitingFor}
 
 -- | Runs a Docker container from an `Image` and `ContainerRequest`. A finalizer
 -- is registered so that the container is aways stopped when it goes out of scope.
 -- This function is essentially @docker run@.
 --
 -- @since 0.1.0.0
---
-run :: MonadDocker m => ContainerRequest -> m Container
+run :: ContainerRequest -> TestContainer Container
 run request = do
+  let ContainerRequest
+        { toImage,
+          naming,
+          cmd,
+          env,
+          exposedPorts,
+          volumeMounts,
+          network,
+          links,
+          rmOnExit,
+          readiness
+        } = request
 
-  let
-    ContainerRequest
-      {
-        toImage
-      , naming
-      , cmd
-      , env
-      , exposedPorts
-      , volumeMounts
-      , network
-      , links
-      , rmOnExit
-      , readiness
-      } = request
-
-  image@Image{ tag } <- runToImage toImage
+  image@Image {tag} <- runToImage toImage
 
   name <-
     case naming of
@@ -494,46 +369,46 @@ run request = do
         Just . (prefix <>) . ("-" <>) . pack
           <$> replicateM 6 (Random.randomRIO ('a', 'z'))
 
-  let
-    dockerRun :: [Text]
-    dockerRun = concat $
-      [ [ "run" ] ] ++
-      [ [ "--detach" ] ] ++
-      [ [ "--name", containerName ] | Just containerName <- [name] ] ++
-      [ [ "--env", variable <> "=" <> value  ] | (variable, value) <- env ] ++
-      [ [ "--publish", pack (show port)] | port <- exposedPorts ] ++
-      [ [ "--network", networkName] | Just networkName <- [network] ] ++
-      [ [ "--link", container ] | container <- links ] ++
-      [ [ "--volume", src <> ":" <> dest ] | (src, dest) <- volumeMounts ] ++
-      [ [ "--rm" ] | rmOnExit ] ++
-      [ [ tag ] ] ++
-      [ command | Just command <- [cmd] ]
+  let dockerRun :: [Text]
+      dockerRun =
+        concat $
+          [["run"]]
+            ++ [["--detach"]]
+            ++ [["--name", containerName] | Just containerName <- [name]]
+            ++ [["--env", variable <> "=" <> value] | (variable, value) <- env]
+            ++ [["--publish", pack (show port)] | port <- exposedPorts]
+            ++ [["--network", networkName] | Just networkName <- [network]]
+            ++ [["--link", container] | container <- links]
+            ++ [["--volume", src <> ":" <> dest] | (src, dest) <- volumeMounts]
+            ++ [["--rm"] | rmOnExit]
+            ++ [[tag]]
+            ++ [command | Just command <- [cmd]]
 
-  config@Config { configTracer } <- ask
+  config@Config {configTracer} <- ask
 
   stdout <- docker configTracer dockerRun
 
-  let
-    id :: ContainerId
-    !id =
-      -- N.B. Force to not leak STDOUT String
-      strip (pack stdout)
+  let id :: ContainerId
+      !id =
+        -- N.B. Force to not leak STDOUT String
+        strip (pack stdout)
 
-    -- Careful, this is really meant to be lazy
-    ~inspectOutput = unsafePerformIO $
-      internalInspect configTracer id
+      -- Careful, this is really meant to be lazy
+      ~inspectOutput =
+        unsafePerformIO $
+          internalInspect configTracer id
 
   container <- liftResourceT $ mfix $ \container -> do
-      -- Note: We have to tie the knot as the resulting container
-      -- carries the release key as well.
-      releaseKey <- register $ runReaderT (runResourceT (stop container)) config
-      pure $ Container
-        {
-          id
-        , releaseKey
-        , image
-        , inspectOutput
-        , config
+    -- Note: We have to tie the knot as the resulting container
+    -- carries the release key as well.
+    releaseKey <- register $ runTestContainer config (stop container)
+    pure $
+      Container
+        { id,
+          releaseKey,
+          image,
+          inspectOutput,
+          config
         }
 
   case readiness of
@@ -544,26 +419,25 @@ run request = do
 
   pure container
 
-
 -- | Internal function that runs Docker. Takes care of throwing an exception
 -- in case of failure.
 --
 -- @since 0.1.0.0
---
 docker :: MonadIO m => Tracer -> [Text] -> m String
 docker tracer args =
   dockerWithStdin tracer args ""
 
-
 -- | Internal function that runs Docker. Takes care of throwing an exception
 -- in case of failure.
 --
 -- @since 0.1.0.0
---
 dockerWithStdin :: MonadIO m => Tracer -> [Text] -> Text -> m String
 dockerWithStdin tracer args stdin = liftIO $ do
-  (exitCode, stdout, stderr) <- Process.readProcessWithExitCode "docker"
-    (map unpack args) (unpack stdin)
+  (exitCode, stdout, stderr) <-
+    Process.readProcessWithExitCode
+      "docker"
+      (map unpack args)
+      (unpack stdin)
 
   withTrace tracer (TraceDockerInvocation args stdin exitCode)
 
@@ -573,91 +447,79 @@ dockerWithStdin tracer args stdin = liftIO $ do
 
   case exitCode of
     ExitSuccess -> pure stdout
-    _ -> throwM $ DockerException
-      {
-        exitCode, args
-      , stderr = pack stderr
-      }
-
+    _ ->
+      throwM $
+        DockerException
+          { exitCode,
+            args,
+            stderr = pack stderr
+          }
 
 -- | Kills a Docker container. `kill` is essentially @docker kill@.
 --
 -- @since 0.1.0.0
---
-kill :: MonadDocker m => Container -> m ()
-kill Container { id } = do
+kill :: Container -> TestContainer ()
+kill Container {id} = do
   tracer <- askTracer
-  _ <- docker tracer [ "kill", id ]
+  _ <- docker tracer ["kill", id]
   return ()
-
 
 -- | Stops a Docker container. `stop` is essentially @docker stop@.
 --
 -- @since 0.1.0.0
---
-stop :: MonadDocker m => Container -> m ()
-stop Container { id } = do
+stop :: Container -> TestContainer ()
+stop Container {id} = do
   tracer <- askTracer
-  _ <- docker tracer [ "stop", id ]
+  _ <- docker tracer ["stop", id]
   return ()
-
 
 -- | Remove a Docker container. `rm` is essentially @docker rm -f@
 --
 -- @since 0.1.0.0
---
-rm :: MonadDocker m => Container -> m ()
-rm Container { id } = do
+rm :: Container -> TestContainer ()
+rm Container {id} = do
   tracer <- askTracer
-  _ <- docker tracer [ "rm", "-f", "-v", id ]
+  _ <- docker tracer ["rm", "-f", "-v", id]
   return ()
-
 
 -- | Access STDOUT and STDERR of a running Docker container. This is essentially
 -- @docker logs@ under the hood.
 --
 -- @since 0.1.0.0
---
-withLogs :: forall m a . MonadDocker m => Container -> (Handle -> Handle -> m a) -> m a
-withLogs Container { id } logger = do
+withLogs :: Container -> (Handle -> Handle -> TestContainer a) -> TestContainer a
+withLogs Container {id} logger = do
+  let acquire :: TestContainer (Handle, Handle, Handle, Process.ProcessHandle)
+      acquire =
+        liftIO $
+          Process.runInteractiveProcess
+            "docker"
+            ["logs", "--follow", unpack id]
+            Nothing
+            Nothing
 
-  let
-    acquire :: m (Handle, Handle, Handle, Process.ProcessHandle)
-    acquire =
-      liftIO $ Process.runInteractiveProcess
-        "docker"
-        [ "logs", "--follow", unpack id ]
-        Nothing
-        Nothing
-
-    release :: (Handle, Handle, Handle, Process.ProcessHandle) -> m ()
-    release (stdin, stdout, stderr, handle) =
-      liftIO $ Process.cleanupProcess
-        (Just stdin, Just stdout, Just stderr, handle)
+      release :: (Handle, Handle, Handle, Process.ProcessHandle) -> TestContainer ()
+      release (stdin, stdout, stderr, handle) =
+        liftIO $
+          Process.cleanupProcess
+            (Just stdin, Just stdout, Just stderr, handle)
 
   bracket acquire release $ \(stdin, stdout, stderr, _handle) -> do
     -- No need to keep it around...
     liftIO $ hClose stdin
     logger stdout stderr
 
-
 -- | A tag to a Docker image.
 --
 -- @since 0.1.0.0
---
 type ImageTag = Text
-
 
 -- | A description of how to build an `Image`.
 --
 -- @since 0.1.0.0
---
 data ToImage = ToImage
-  {
-    runToImage              :: forall m. MonadDocker m => m Image
-  , applyToContainerRequest :: ContainerRequest -> ContainerRequest
+  { runToImage :: TestContainer Image,
+    applyToContainerRequest :: ContainerRequest -> ContainerRequest
   }
-
 
 -- | Build the `Image` referred to by the argument. If the construction of the
 -- image is expensive (e.g. a call to `fromBuildContext`) we don't want to
@@ -665,138 +527,113 @@ data ToImage = ToImage
 -- underlying Docker build once and re-use the resulting `Image`.
 --
 -- @since 0.1.0.0
---
-build :: MonadDocker m => ToImage -> m ToImage
-build toImage@ToImage { applyToContainerRequest } = do
+build :: ToImage -> TestContainer ToImage
+build toImage@ToImage {applyToContainerRequest} = do
   image <- runToImage toImage
-  return $ ToImage
-    {
-      runToImage = pure image
-    , applyToContainerRequest
-    }
-
+  return $
+    ToImage
+      { runToImage = pure image,
+        applyToContainerRequest
+      }
 
 -- | Default `ToImage`. Doesn't apply anything to to `ContainerRequests`.
 --
 -- @since 0.1.0.0
---
-defaultToImage :: (forall m . MonadDocker m => m Image) -> ToImage
-defaultToImage action = ToImage
-  {
-    runToImage = action
-  , applyToContainerRequest = \x -> x
-  }
-
+defaultToImage :: TestContainer Image -> ToImage
+defaultToImage action =
+  ToImage
+    { runToImage = action,
+      applyToContainerRequest = \x -> x
+    }
 
 -- | Get an `Image` from a tag.
 --
 -- @since 0.1.0.0
---
 fromTag :: ImageTag -> ToImage
 fromTag tag = defaultToImage $ do
   tracer <- askTracer
-  output <- docker tracer [ "pull", "--quiet", tag ]
-  return $ Image
-    {
-      tag = strip (pack output)
-    }
-
+  output <- docker tracer ["pull", "--quiet", tag]
+  return $
+    Image
+      { tag = strip (pack output)
+      }
 
 -- | Build the image from a build path and an optional path to the
 -- Dockerfile (default is Dockerfile)
 --
 -- @since 0.1.0.0
---
-fromBuildContext
-  :: FilePath
-  -> Maybe FilePath
-  -> ToImage
+fromBuildContext ::
+  FilePath ->
+  Maybe FilePath ->
+  ToImage
 fromBuildContext path mdockerfile = defaultToImage $ do
-  let
-    args
-      | Just dockerfile <- mdockerfile =
-          [ "build", "--quiet", "-f", pack dockerfile, pack path ]
-      | otherwise =
-          [ "build", "--quiet", pack path ]
+  let args
+        | Just dockerfile <- mdockerfile =
+            ["build", "--quiet", "-f", pack dockerfile, pack path]
+        | otherwise =
+            ["build", "--quiet", pack path]
   tracer <- askTracer
   output <- docker tracer args
-  return $ Image
-    {
-      tag = strip (pack output)
-    }
-
+  return $
+    Image
+      { tag = strip (pack output)
+      }
 
 -- | Build a contextless image only from a Dockerfile passed as `Text`.
 --
 -- @since 0.1.0.0
---
-fromDockerfile
-  :: Text
-  -> ToImage
+fromDockerfile ::
+  Text ->
+  ToImage
 fromDockerfile dockerfile = defaultToImage $ do
   tracer <- askTracer
-  output <- dockerWithStdin tracer [ "build", "--quiet", "-" ] dockerfile
-  return $ Image
-    {
-      tag = strip (pack output)
-    }
-
+  output <- dockerWithStdin tracer ["build", "--quiet", "-"] dockerfile
+  return $
+    Image
+      { tag = strip (pack output)
+      }
 
 -- | Identifies a container within the Docker runtime. Assigned by @docker run@.
 --
 -- @since 0.1.0.0
---
 type ContainerId = Text
-
 
 -- | A strategy that describes how to asses readiness of a `Container`. Allows
 -- Users to plug in their definition of readiness.
 --
 -- @since 0.1.0.0
---
 newtype WaitUntilReady = WaitUntilReady
-  {
-    checkContainerReady :: Config -> Container -> (Maybe Int, ResIO ())
+  { checkContainerReady :: Config -> Container -> (Maybe Int, TestContainer ())
   }
-
 
 -- | The exception thrown by `waitForLine` in case the expected log line
 -- wasn't found.
 --
 -- @since 0.1.0.0
---
 newtype UnexpectedEndOfPipe = UnexpectedEndOfPipe
-  {
-    -- | The id of the underlying container.
+  { -- | The id of the underlying container.
     id :: ContainerId
   }
   deriving (Eq, Show)
 
-
 instance Exception UnexpectedEndOfPipe
-
 
 -- | The exception thrown by `waitUntilTimeout`.
 --
 -- @since 0.1.0.0
---
 newtype TimeoutException = TimeoutException
-  {
-    -- | The id of the underlying container that was not ready in time.
+  { -- | The id of the underlying container that was not ready in time.
     id :: ContainerId
   }
   deriving (Eq, Show)
 
-
 instance Exception TimeoutException
-
 
 -- | @waitUntilTimeout n waitUntilReady@ waits @n@ seconds for the container
 -- to be ready. If the container is not ready by then a `TimeoutException` will
 -- be thrown.
 --
 -- @since 0.1.0.0
---
 waitUntilTimeout :: Int -> WaitUntilReady -> WaitUntilReady
 waitUntilTimeout seconds wait = WaitUntilReady $ \config container ->
   case checkContainerReady wait config container of
@@ -808,58 +645,53 @@ waitUntilTimeout seconds wait = WaitUntilReady $ \config container ->
       | otherwise ->
           (Just innerTimeout, check)
 
-
 -- | Waits until the port of a container is ready to accept connections.
 -- This combinator should always be used with `waitUntilTimeout`.
 --
 -- @since 0.1.0.0
---
-waitUntilMappedPortReachable
-  :: Int
-  -> WaitUntilReady
+waitUntilMappedPortReachable ::
+  Int ->
+  WaitUntilReady
 waitUntilMappedPortReachable port = WaitUntilReady $ \config container ->
   withFrozenCallStack $
+    let Config {configTracer} = config
 
-  let
-    Config { configTracer } = config
+        resolve hostIp hostPort = do
+          let hints = Socket.defaultHints {Socket.addrSocketType = Socket.Stream}
+          head <$> Socket.getAddrInfo (Just hints) (Just hostIp) (Just (show hostPort))
 
-    resolve hostIp hostPort = do
-      let hints = Socket.defaultHints { Socket.addrSocketType = Socket.Stream }
-      head <$> Socket.getAddrInfo (Just hints) (Just hostIp) (Just (show hostPort))
+        open addr = do
+          socket <-
+            Socket.socket
+              (Socket.addrFamily addr)
+              (Socket.addrSocketType addr)
+              (Socket.addrProtocol addr)
+          Socket.connect
+            socket
+            (Socket.addrAddress addr)
+          pure socket
 
-    open addr = do
-      socket <- Socket.socket
-        (Socket.addrFamily addr)
-        (Socket.addrSocketType addr)
-        (Socket.addrProtocol addr)
-      Socket.connect
-        socket
-        (Socket.addrAddress addr)
-      pure socket
+        retry = do
+          inDocker <- isRunningInDocker
+          let hostIp =
+                if inDocker
+                  then unpack $ containerGateway container
+                  else "localhost"
+              hostPort = containerPort container port
 
-    retry = do
-      inDocker <- isRunningInDocker
-      let hostIp = if inDocker
-                       then unpack $ containerGateway container
-                       else "localhost"
-          hostPort = containerPort container port
-
-      result <- try (resolve hostIp hostPort >>= open)
-      case result of
-        Right socket -> do
-          withTrace configTracer (TraceOpenSocket (pack hostIp) hostPort Nothing)
-          Socket.close socket
-          pure ()
-
-        Left (exception :: IOException) -> do
-          withTrace configTracer
-            (TraceOpenSocket (pack hostIp) hostPort (Just exception))
-          threadDelay 500000
-          retry
-
-  in
-    (Nothing, liftIO retry)
-
+          result <- try (resolve hostIp hostPort >>= open)
+          case result of
+            Right socket -> do
+              withTrace configTracer (TraceOpenSocket (pack hostIp) hostPort Nothing)
+              Socket.close socket
+              pure ()
+            Left (exception :: IOException) -> do
+              withTrace
+                configTracer
+                (TraceOpenSocket (pack hostIp) hostPort (Just exception))
+              threadDelay 500000
+              retry
+     in (Nothing, liftIO retry)
 
 -- | A low-level primitive that allows scanning the logs for specific log lines
 -- that indicate readiness of a container.
@@ -868,27 +700,21 @@ waitUntilMappedPortReachable port = WaitUntilReady $ \config container ->
 -- of the container.
 --
 -- @since 0.1.0.0
---
 waitWithLogs :: (Container -> Handle -> Handle -> IO ()) -> WaitUntilReady
-waitWithLogs waiter = WaitUntilReady $ \config container ->
-  let
-    check = flip runReaderT config $ withLogs container $ \stdout stderr ->
-      liftIO $ waiter container stdout stderr
-  in
-    (Nothing, check)
-
+waitWithLogs waiter = WaitUntilReady $ \_config container ->
+  let check = withLogs container $ \stdout stderr ->
+        liftIO $ waiter container stdout stderr
+   in (Nothing, check)
 
 -- | A data type indicating which pipe to scan for a specific log line.
 --
 -- @since 0.1.0.0
---
 data Pipe
-  -- | Refer to logs on STDOUT.
-  = Stdout
-  -- | Refer to logs on STDERR.
-  | Stderr
+  = -- | Refer to logs on STDOUT.
+    Stdout
+  | -- | Refer to logs on STDERR.
+    Stderr
   deriving (Eq, Ord, Show)
-
 
 -- | Waits for a specific line to occur in the logs. Throws a `UnexpectedEndOfPipe`
 -- exception in case the desired line can not be found on the logs.
@@ -900,258 +726,219 @@ data Pipe
 -- @
 --
 -- @since 0.1.0.0
---
 waitForLogLine :: Pipe -> (LazyText.Text -> Bool) -> WaitUntilReady
-waitForLogLine whereToLook matches = waitWithLogs $ \Container { id } stdout stderr -> do
-  let
-    logs :: Handle
-    logs = case whereToLook of
-      Stdout -> stdout
-      Stderr -> stderr
+waitForLogLine whereToLook matches = waitWithLogs $ \Container {id} stdout stderr -> do
+  let logs :: Handle
+      logs = case whereToLook of
+        Stdout -> stdout
+        Stderr -> stderr
 
   logContent <- LazyByteString.hGetContents logs
 
-  let
-    logLines :: [LazyText.Text]
-    logLines =
-      -- FIXME: This is assuming UTF8 encoding. Do better!
-      map
-        (LazyText.decodeUtf8With lenientDecode)
-        (LazyByteString.lines logContent)
+  let logLines :: [LazyText.Text]
+      logLines =
+        -- FIXME: This is assuming UTF8 encoding. Do better!
+        map
+          (LazyText.decodeUtf8With lenientDecode)
+          (LazyByteString.lines logContent)
 
   case find matches logLines of
-    Just _  -> pure ()
-    Nothing -> throwM $ UnexpectedEndOfPipe { id }
-
+    Just _ -> pure ()
+    Nothing -> throwM $ UnexpectedEndOfPipe {id}
 
 -- | Blocks until the container is ready. `waitUntilReady` might throw exceptions
 -- depending on the used `WaitUntilReady` on the container.
 --
 -- @since 0.1.0.0
---
-waitUntilReady :: MonadDocker m => Container -> WaitUntilReady -> m ()
-waitUntilReady container@Container { id } waiter = do
-  config@Config { configDefaultWaitTimeout, configTracer } <- ask
-  let
-    (timeoutInSeconds, check) =
-      checkContainerReady waiter config container
+waitUntilReady :: Container -> WaitUntilReady -> TestContainer ()
+waitUntilReady container@Container {id} waiter = do
+  config@Config {configDefaultWaitTimeout, configTracer} <- ask
+  let (timeoutInSeconds, check) =
+        checkContainerReady waiter config container
 
-    runAction action timeoutSeconds = do
-      withTrace configTracer (TraceWaitUntilReady timeoutSeconds)
-      action
+      runAction action timeoutSeconds = do
+        withTrace configTracer (TraceWaitUntilReady timeoutSeconds)
+        action
 
-    withTimeout action = case timeoutInSeconds <|> configDefaultWaitTimeout of
-      Nothing ->
-        runAction action Nothing
-      Just seconds ->
-        withRunInIO $ \runInIO -> do
-          result <- timeout (seconds * 1000000) $ runInIO (runAction action (Just seconds))
-          case result of
-            Nothing ->
-              throwM $ TimeoutException { id }
-            Just _ ->
-              pure ()
+      withTimeout action = case timeoutInSeconds <|> configDefaultWaitTimeout of
+        Nothing ->
+          runAction action Nothing
+        Just seconds ->
+          withRunInIO $ \runInIO -> do
+            result <- timeout (seconds * 1000000) $ runInIO (runAction action (Just seconds))
+            case result of
+              Nothing ->
+                throwM $ TimeoutException {id}
+              Just _ ->
+                pure ()
 
-  liftResourceT (withTimeout check)
-
+  withTimeout check
 
 -- | Handle to a Docker image.
 --
 -- @since 0.1.0.0
---
 data Image = Image
-  {
-    -- | The image tag assigned by Docker. Uniquely identifies an `Image`
+  { -- | The image tag assigned by Docker. Uniquely identifies an `Image`
     -- within Docker.
     tag :: ImageTag
   }
   deriving (Eq, Show)
 
-
 -- | The image tag assigned by Docker. Uniquely identifies an `Image`
 -- within Docker.
 --
 -- @since 0.1.0.0
---
 imageTag :: Image -> ImageTag
-imageTag Image { tag } = tag
-
+imageTag Image {tag} = tag
 
 -- | Handle to a Docker container.
 --
 -- @since 0.1.0.0
---
 data Container = Container
-  {
-    -- | The container Id assigned by Docker, uniquely identifying this `Container`.
-    id            :: ContainerId
+  { -- | The container Id assigned by Docker, uniquely identifying this `Container`.
+    id :: ContainerId,
     -- | Underlying `ReleaseKey` for the resource finalizer.
-  , releaseKey    :: ReleaseKey
+    releaseKey :: ReleaseKey,
     -- | The underlying `Image` of this container.
-  , image         :: Image
+    image :: Image,
     -- | Configuration used to create and run this container.
-  , config        :: Config
+    config :: Config,
     -- | Memoized output of `docker inspect`. This is being calculated lazily.
-  , inspectOutput :: InspectOutput
+    inspectOutput :: InspectOutput
   }
-
 
 -- | The parsed JSON output of docker inspect command.
 --
 -- @since 0.1.0.0
---
 type InspectOutput = Value
-
 
 -- | Returns the id of the container.
 --
 -- @since 0.1.0.0
---
 containerId :: Container -> ContainerId
-containerId Container { id } = id
-
+containerId Container {id} = id
 
 -- | Returns the underlying image of the container.
 --
 -- @since 0.1.0.0
---
 containerImage :: Container -> Image
-containerImage Container { image } = image
-
+containerImage Container {image} = image
 
 -- | Returns the internal release key used for safely shutting down
 -- the container. Use this with care. This function is considered
 -- an internal detail.
 --
 -- @since 0.1.0.0
---
 containerReleaseKey :: Container -> ReleaseKey
-containerReleaseKey Container { releaseKey } = releaseKey
-
+containerReleaseKey Container {releaseKey} = releaseKey
 
 -- | Looks up the ip address of the container.
 --
 -- @since 0.1.0.0
---
 containerIp :: Container -> Text
 containerIp =
   internalContainerIp
 
-
 -- | Get the IP address of a running Docker container using @docker inspect@.
 internalContainerIp :: Container -> Text
-internalContainerIp Container { id, inspectOutput } =
+internalContainerIp Container {id, inspectOutput} =
   case inspectOutput
     ^? Optics.key "NetworkSettings"
     % Optics.key "IPAddress"
     % Optics._String of
-
     Nothing ->
-      throw $ InspectOutputUnexpected { id }
-
+      throw $ InspectOutputUnexpected {id}
     Just address ->
       address
-
 
 -- | Get the IP address for the container's gateway, i.e. the host.
 -- Takes the first gateway address found.
 --
 -- @since 0.4.0.0
---
 containerGateway :: Container -> Text
-containerGateway Container { id, inspectOutput } =
-    case inspectOutput
-    ^? pre (Optics.key "NetworkSettings"
-           % Optics.key "Networks"
-           % Optics.members
-           % Optics.key "Gateway"
-           % Optics._String) of
-
-      Nothing ->
-        throw $ InspectOutputMissingNetwork
-          {
-            id
+containerGateway Container {id, inspectOutput} =
+  case inspectOutput
+    ^? pre
+      ( Optics.key "NetworkSettings"
+          % Optics.key "Networks"
+          % Optics.members
+          % Optics.key "Gateway"
+          % Optics._String
+      ) of
+    Nothing ->
+      throw $
+        InspectOutputMissingNetwork
+          { id
           }
-      Just gatewayIp ->
-        gatewayIp
-
+    Just gatewayIp ->
+      gatewayIp
 
 -- | Looks up an exposed port on the host.
 --
 -- @since 0.1.0.0
---
 containerPort :: Container -> Int -> Int
-containerPort Container { id, inspectOutput } port =
-  let
-    -- TODO also support UDP ports
-    textPort :: Text
-    textPort = pack (show port) <> "/tcp"
-  in
-    -- TODO be more mindful, make sure to grab the
-    -- port from the right host address
+containerPort Container {id, inspectOutput} port =
+  let -- TODO also support UDP ports
+      textPort :: Text
+      textPort = pack (show port) <> "/tcp"
+   in -- TODO be more mindful, make sure to grab the
+      -- port from the right host address
 
-    case inspectOutput
-    ^? pre (Optics.key "NetworkSettings"
-           % Optics.key "Ports"
-           % Optics.key (toKey textPort)
-           % Optics.values
-           % Optics.key "HostPort"
-           % Optics._String) of
-
-      Nothing ->
-        throw $ UnknownPortMapping
-          {
-            id
-          , port = textPort
-          }
-      Just hostPort ->
-        read (unpack hostPort)
-
+      case inspectOutput
+        ^? pre
+          ( Optics.key "NetworkSettings"
+              % Optics.key "Ports"
+              % Optics.key (toKey textPort)
+              % Optics.values
+              % Optics.key "HostPort"
+              % Optics._String
+          ) of
+        Nothing ->
+          throw $
+            UnknownPortMapping
+              { id,
+                port = textPort
+              }
+        Just hostPort ->
+          read (unpack hostPort)
 
 -- | Runs the `docker inspect` command. Memoizes the result.
 --
 -- @since 0.1.0.0
---
-inspect :: MonadDocker m => Container -> m InspectOutput
-inspect Container { inspectOutput } =
+inspect :: Container -> TestContainer InspectOutput
+inspect Container {inspectOutput} =
   pure inspectOutput
-
 
 -- | Runs the `docker inspect` command.
 --
 -- @since 0.1.0.0
---
 internalInspect :: (MonadThrow m, MonadIO m) => Tracer -> ContainerId -> m InspectOutput
 internalInspect tracer id = do
-  stdout <- docker tracer [ "inspect", id ]
+  stdout <- docker tracer ["inspect", id]
   case decode' (LazyByteString.pack stdout) of
     Nothing ->
-      throwM $ InspectOutputInvalidJSON { id }
+      throwM $ InspectOutputInvalidJSON {id}
     Just [] ->
-      throwM $ InspectUnknownContainerId { id }
+      throwM $ InspectUnknownContainerId {id}
     Just [value] ->
       pure value
     Just _ ->
       Prelude.error "Internal: Multiple results where I expected single result"
 
-
-askTracer :: MonadReader Config m => m Tracer
+askTracer :: TestContainer Tracer
 askTracer = do
-  Config { configTracer } <- ask
+  Config {configTracer} <- ask
   pure configTracer
 {-# INLINE askTracer #-}
 
-
-dockerHostOs :: MonadDocker m => m Text
+dockerHostOs :: TestContainer Text
 dockerHostOs = do
   tracer <- askTracer
-  strip . pack <$> docker tracer [ "version", "--format", "{{.Server.Os}}" ]
+  strip . pack <$> docker tracer ["version", "--format", "{{.Server.Os}}"]
 
-
-isDockerOnLinux :: MonadDocker m => m Bool
+isDockerOnLinux :: TestContainer Bool
 isDockerOnLinux =
   ("linux" ==) <$> dockerHostOs
-
 
 -- | Detects if we are actually running in a Docker container.
 isRunningInDocker :: MonadIO m => m Bool

--- a/src/TestContainers/Docker.hs
+++ b/src/TestContainers/Docker.hs
@@ -156,7 +156,7 @@ import           System.IO                    (Handle, hClose)
 import           System.IO.Unsafe             (unsafePerformIO)
 import qualified System.Process               as Process
 import           System.Timeout               (timeout)
-
+import           TestContainers.AesonCompat   (toKey)
 
 -- | Type representing various events during testcontainer execution.
 data Trace
@@ -1093,7 +1093,7 @@ containerPort Container { id, inspectOutput } port =
     case inspectOutput
     ^? pre (Optics.key "NetworkSettings"
            % Optics.key "Ports"
-           % Optics.key textPort
+           % Optics.key (toKey textPort)
            % Optics.values
            % Optics.key "HostPort"
            % Optics._String) of

--- a/src/TestContainers/Image.hs
+++ b/src/TestContainers/Image.hs
@@ -1,20 +1,23 @@
 {-# LANGUAGE OverloadedStrings #-}
-module TestContainers.Image
-  (
-    -- * Collection of pre-defined Docker images
-    redis
 
-  , mongo
+module TestContainers.Image
+  ( -- * Collection of pre-defined Docker images
+    redis,
+    mongo,
 
     -- * Building and managing images
-  , module Docker
+    module Docker,
+  )
+where
 
-  ) where
-
-import           TestContainers.Docker as Docker (Image, ToImage, build,
-                                                  fromBuildContext,
-                                                  fromDockerfile, fromTag)
-
+import TestContainers.Docker as Docker
+  ( Image,
+    ToImage,
+    build,
+    fromBuildContext,
+    fromDockerfile,
+    fromTag,
+  )
 
 -- | Image for Redis database.
 --
@@ -23,11 +26,9 @@ import           TestContainers.Docker as Docker (Image, ToImage, build,
 -- @
 --
 -- @since 0.1.0.0
---
 redis :: ToImage
 redis =
   fromTag "redis:5.0"
-
 
 -- | Image for Mongo database.
 --
@@ -36,7 +37,6 @@ redis =
 -- @
 --
 -- @since 0.1.0.0
---
 mongo :: ToImage
 mongo =
   fromTag "mongo:4.0.17"

--- a/src/TestContainers/Monad.hs
+++ b/src/TestContainers/Monad.hs
@@ -1,0 +1,81 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE TypeOperators #-}
+
+module TestContainers.Monad
+  ( -- * Configuration
+    Config (..),
+    defaultDockerConfig,
+    determineConfig,
+
+    -- * Monad
+    MonadDocker,
+    TestContainer,
+    runTestContainer,
+  )
+where
+
+import Control.Monad.Catch (MonadCatch, MonadMask, MonadThrow)
+import Control.Monad.IO.Class (MonadIO)
+import Control.Monad.IO.Unlift (MonadUnliftIO)
+import Control.Monad.Reader (MonadReader, ReaderT, runReaderT)
+import Control.Monad.Trans.Resource (MonadResource, ResourceT, runResourceT)
+import TestContainers.Tracer (Tracer)
+
+-- | Configuration for defaulting behavior.
+--
+-- @since 0.2.0.0
+data Config = Config
+  { -- | The number of seconds to maximally wait for a container to
+    -- become ready. Default is `Just 60`.
+    --
+    -- @Nothing@ <=> waits indefinitely.
+    configDefaultWaitTimeout :: Maybe Int,
+    -- | Traces execution inside testcontainers library.
+    configTracer :: Tracer
+  }
+
+-- \| Default configuration.
+--
+-- @since 0.2.0.0
+defaultDockerConfig :: Config
+defaultDockerConfig =
+  Config
+    { configDefaultWaitTimeout = Just 60,
+      configTracer = mempty
+    }
+
+-- | Autoselect the default configuration depending on wether you use Docker For
+-- Mac or not.
+determineConfig :: IO Config
+determineConfig =
+  pure defaultDockerConfig
+
+-- | Docker related functionality is parameterized over this `Monad`.
+--
+-- @since 0.1.0.0
+type MonadDocker m = (m ~ TestContainer)
+
+{-# DEPRECATED MonadDocker "Use 'TestContainer' monad instead" #-}
+
+-- | Concrete monad that is used to orchestrate containers.
+-- 
+-- @since x.x.x.x
+newtype TestContainer a = TestContainer {unTestContainer :: ReaderT Config (ResourceT IO) a}
+  deriving newtype
+    ( Functor,
+      Applicative,
+      Monad,
+      MonadIO,
+      MonadMask,
+      MonadThrow,
+      MonadCatch,
+      MonadResource,
+      MonadReader Config,
+      MonadUnliftIO
+    )
+
+runTestContainer :: Config -> TestContainer a -> IO a
+runTestContainer config action =
+  runResourceT (runReaderT (unTestContainer action) config)

--- a/src/TestContainers/Tasty.hs
+++ b/src/TestContainers/Tasty.hs
@@ -1,44 +1,53 @@
-{-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+
 module TestContainers.Tasty
-  (
-    -- * Tasty Ingredient
-    ingredient
+  ( -- * Tasty Ingredient
+    ingredient,
 
     -- * Running containers for tests
-  , withContainers
+    withContainers,
 
     -- * Re-exports for convenience
-  , module Reexports
-  ) where
+    module Reexports,
+  )
+where
 
-import           Control.Applicative                   ((<|>))
-import           Control.Monad.IO.Class                (liftIO)
-import           Control.Monad.Reader                  (runReaderT)
-import           Control.Monad.Trans.Resource          (InternalState,
-                                                        getInternalState)
-import           Control.Monad.Trans.Resource.Internal (stateAlloc,
-                                                        stateCleanup)
-import           Data.Acquire                          (ReleaseType (ReleaseNormal))
-import           Data.Data                             (Proxy (Proxy))
-import           Test.Tasty                            (TestTree, askOption,
-                                                        withResource)
-import qualified Test.Tasty                            as Tasty
-import           Test.Tasty.Ingredients                (Ingredient)
-import           Test.Tasty.Options                    (IsOption (..),
-                                                        OptionDescription (..),
-                                                        mkFlagCLParser,
-                                                        safeRead)
-import           TestContainers                        as Reexports hiding
-                                                                    (Trace)
-
+import Control.Applicative ((<|>))
+import Control.Monad.IO.Class (liftIO)
+import Control.Monad.Trans.Resource
+  ( InternalState,
+    getInternalState,
+    liftResourceT,
+  )
+import Control.Monad.Trans.Resource.Internal
+  ( stateAlloc,
+    stateCleanup,
+  )
+import Data.Acquire (ReleaseType (ReleaseNormal))
+import Data.Data (Proxy (Proxy))
+import Test.Tasty
+  ( TestTree,
+    askOption,
+    withResource,
+  )
+import qualified Test.Tasty as Tasty
+import Test.Tasty.Ingredients (Ingredient)
+import Test.Tasty.Options
+  ( IsOption (..),
+    OptionDescription (..),
+    mkFlagCLParser,
+    safeRead,
+  )
+import TestContainers as Reexports hiding
+  ( Trace,
+  )
+import TestContainers.Monad (runTestContainer)
 
 newtype DefaultTimeout = DefaultTimeout (Maybe Int)
 
-
 instance IsOption DefaultTimeout where
-
   defaultValue =
     DefaultTimeout Nothing
 
@@ -51,12 +60,9 @@ instance IsOption DefaultTimeout where
   optionHelp =
     pure "The max. number of seconds to wait for a container to become ready"
 
-
 newtype Trace = Trace Bool
 
-
 instance IsOption Trace where
-
   defaultValue =
     Trace False
 
@@ -72,7 +78,6 @@ instance IsOption Trace where
   optionHelp =
     pure "Turns on tracing of the underlying Docker operations"
 
-
 -- | Tasty `Ingredient` that adds useful options to control defaults within the
 -- TetContainers library.
 --
@@ -82,67 +87,62 @@ instance IsOption Trace where
 -- @
 --
 -- @since 0.3.0.0
---
 ingredient :: Ingredient
-ingredient = Tasty.includingOptions
-  [
-    Option (Proxy :: Proxy DefaultTimeout)
-  , Option (Proxy :: Proxy Trace)
-  ]
+ingredient =
+  Tasty.includingOptions
+    [ Option (Proxy :: Proxy DefaultTimeout),
+      Option (Proxy :: Proxy Trace)
+    ]
 
-
-withContainers
-  :: forall a
-  .  (forall m. MonadDocker m => m a)
-  -> (IO a -> TestTree)
-  -> TestTree
+withContainers ::
+  forall a.
+  TestContainer a ->
+  (IO a -> TestTree) ->
+  TestTree
 withContainers startContainers tests =
-  askOption $ \ (DefaultTimeout defaultTimeout) ->
-  askOption $ \ (Trace enableTrace) ->
-  let
-    tracer :: Tracer
-    tracer
-      | enableTrace = newTracer $ \message ->
-          putStrLn (show message)
-      | otherwise =
-          mempty
+  askOption $ \(DefaultTimeout defaultTimeout) ->
+    askOption $ \(Trace enableTrace) ->
+      let tracer :: Tracer
+          tracer
+            | enableTrace = newTracer $ \message ->
+                putStrLn (show message)
+            | otherwise =
+                mempty
 
-    runC action = do
-      config <- determineConfig
+          runC action = do
+            config <- determineConfig
 
-      let
-        actualConfig :: Config
-        actualConfig = config
-          {
-            configDefaultWaitTimeout =
-              defaultTimeout <|> configDefaultWaitTimeout config
-          , configTracer = tracer
-          }
+            let actualConfig :: Config
+                actualConfig =
+                  config
+                    { configDefaultWaitTimeout =
+                        defaultTimeout <|> configDefaultWaitTimeout config,
+                      configTracer = tracer
+                    }
 
-      runReaderT (runResourceT action) actualConfig
+            runTestContainer actualConfig action
 
-    -- Correct resource handling is tricky here:
-    -- Tasty offers a bracket alike in IO. We  have
-    -- to transfer the ReleaseMap of the ResIO safely
-    -- to the release function. Fortunately resourcet
-    -- let's us access the internal state..
-    acquire :: IO (a, InternalState)
-    acquire = runC $ do
-      result     <- startContainers
-      releaseMap <- getInternalState
+          -- Correct resource handling is tricky here:
+          -- Tasty offers a bracket alike in IO. We  have
+          -- to transfer the ReleaseMap of the ResIO safely
+          -- to the release function. Fortunately resourcet
+          -- let's us access the internal state..
+          acquire :: IO (a, InternalState)
+          acquire = runC $ do
+            result <- startContainers
+            releaseMap <- liftResourceT getInternalState
 
-      -- N.B. runResourceT runs the finalizers on every
-      -- resource. We don't want it to! We want to run
-      -- finalization in the release function that is
-      -- called by Tasty! stateAlloc increments a references
-      -- count to accomodate for exactly these kind of
-      -- cases.
-      liftIO $ stateAlloc releaseMap
-      pure (result, releaseMap)
+            -- N.B. runResourceT runs the finalizers on every
+            -- resource. We don't want it to! We want to run
+            -- finalization in the release function that is
+            -- called by Tasty! stateAlloc increments a references
+            -- count to accomodate for exactly these kind of
+            -- cases.
+            liftIO $ stateAlloc releaseMap
+            pure (result, releaseMap)
 
-    release :: (a, InternalState) -> IO ()
-    release (_, internalState) =
-      stateCleanup ReleaseNormal internalState
-  in
-    withResource acquire release $ \mk ->
-      tests (fmap fst mk)
+          release :: (a, InternalState) -> IO ()
+          release (_, internalState) =
+            stateCleanup ReleaseNormal internalState
+       in withResource acquire release $ \mk ->
+            tests (fmap fst mk)

--- a/src/TestContainers/Tracer.hs
+++ b/src/TestContainers/Tracer.hs
@@ -1,0 +1,52 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+module TestContainers.Tracer
+  ( Trace (..),
+    Tracer,
+    newTracer,
+    withTrace,
+  )
+where
+
+import Control.Exception (IOException)
+import Control.Monad.IO.Class (MonadIO, liftIO)
+import Data.Text (Text)
+import System.Exit (ExitCode)
+
+-- | Type representing various events during testcontainer execution.
+data Trace
+  = -- | The low-level invocation of @docker@ command
+    --
+    -- @
+    --   TraceDockerInvocation args stdin exitcode
+    -- @
+    TraceDockerInvocation [Text] Text ExitCode -- docker [args] [stdin]
+  | -- | Line written to STDOUT by a Docker process.
+    TraceDockerStdout Text
+  | -- | Line written to STDERR by a Docker process.
+    TraceDockerStderr Text
+  | -- | Waiting for a container to become ready. Attached with the
+    -- timeout to wait (in seconds).
+    TraceWaitUntilReady (Maybe Int)
+  | -- | Opening socket
+    TraceOpenSocket Text Int (Maybe IOException)
+  deriving stock (Eq, Show)
+
+-- | Traces execution within testcontainers library.
+newtype Tracer = Tracer {unTracer :: Trace -> IO ()}
+  deriving newtype (Semigroup, Monoid)
+
+-- | Construct a new `Tracer` from a tracing function.
+newTracer ::
+  (Trace -> IO ()) ->
+  Tracer
+newTracer action =
+  Tracer
+    { unTracer = action
+    }
+
+withTrace :: MonadIO m => Tracer -> Trace -> m ()
+withTrace tracer trace =
+  liftIO $ unTracer tracer trace
+{-# INLINE withTrace #-}

--- a/testcontainers.cabal
+++ b/testcontainers.cabal
@@ -1,69 +1,81 @@
-cabal-version:       >=1.10
-name:                testcontainers
-version:             0.3.1.0
-synopsis:            Docker containers for your integration tests.
-description:         testcontainers is a Haskell library that provides a friendly API to
-                     run Docker containers. It is designed to create a runtime environment
-                     to use during your integration tests
+cabal-version:      >=1.10
+name:               testcontainers
+version:            0.3.1.0
+synopsis:           Docker containers for your integration tests.
+description:
+  testcontainers is a Haskell library that provides a friendly API to
+  run Docker containers. It is designed to create a runtime environment
+  to use during your integration tests
+
 -- bug-reports:
-license:             MIT
-license-file:        LICENSE
-author:              Alex Biehl
-maintainer:          alex.biehl@target.com
-copyright:           2020 Alex Biehl
-category:            Development
-build-type:          Simple
-extra-source-files:  CHANGELOG.md,
-                     README.md
+license:            MIT
+license-file:       LICENSE
+author:             Alex Biehl
+maintainer:         alex.biehl@target.com
+copyright:          2020 Alex Biehl
+category:           Development
+build-type:         Simple
+extra-source-files:
+  CHANGELOG.md
+  README.md
 
 source-repository head
-  type: git
+  type:     git
   location: https://github.com/alexbiehl/testcontainers-hs
 
 library
-  exposed-modules:     TestContainers
-                       TestContainers.Docker
-                       TestContainers.Hspec
-                       TestContainers.Image
-                       TestContainers.Tasty
+  exposed-modules:
+    TestContainers
+    TestContainers.Docker
+    TestContainers.Hspec
+    TestContainers.Image
+    TestContainers.Monad
+    TestContainers.Tasty
+    TestContainers.Tracer
 
-  other-modules:       TestContainers.AesonCompat
+  other-modules:    TestContainers.AesonCompat
+
   -- other-extensions:
-  build-depends:       base                 >=4.12 && <5,
-                       aeson                >= 1.4.6 && < 3,
-                       aeson-optics         >= 1.1 && < 2,
-                       bytestring           >= 0.10.8 && < 0.12,
-                       text                 >= 1.2.3 && < 3,
-                       exceptions           >= 0.10.4 && < 0.11,
-                       optics-core          >= 0.1 && < 0.5,
-                       process              >= 1.6.5 && < 1.7,
-                       network              >= 2.8.0 && < 3.2,
-                       mtl                  >= 2.2.2 && < 3,
-                       resourcet            >= 1.2.4 && < 1.3,
-                       unliftio-core        >= 0.1.0 && < 0.3,
-                       tasty                >= 1.0   && < 1.5,
-                       random               >= 1.2   && < 2,
-                       directory            >= 1.3.6 && < 2
+  build-depends:
+      aeson          >=1.4.6  && <3
+    , aeson-optics   >=1.1    && <2
+    , base           >=4.12   && <5
+    , bytestring     >=0.10.8 && <0.12
+    , directory      >=1.3.6  && <2
+    , exceptions     >=0.10.4 && <0.11
+    , mtl            >=2.2.2  && <3
+    , network        >=2.8.0  && <3.2
+    , optics-core    >=0.1    && <0.5
+    , process        >=1.6.5  && <1.7
+    , random         >=1.2    && <2
+    , resourcet      >=1.2.4  && <1.3
+    , tasty          >=1.0    && <1.5
+    , text           >=1.2.3  && <3
+    , unliftio-core  >=0.1.0  && <0.3
 
-  hs-source-dirs:      src
-  default-language:    Haskell2010
-  ghc-options:         -Wall
+  hs-source-dirs:   src
+  default-language: Haskell2010
+  ghc-options:      -Wall
 
 test-suite tests
-  hs-source-dirs:      test
-  default-language:    Haskell2010
-  ghc-options:         -Wall
-  type:                exitcode-stdio-1.0
-  main-is:             Driver.hs
-  other-modules:       TestContainers.HspecSpec
-                       TestContainers.TastySpec
-  build-tool-depends:  hspec-discover:hspec-discover,
-                       tasty-discover:tasty-discover
-  build-depends:       base,
-                       hspec >= 2.0 && < 3.0,
-                       tasty,
-                       tasty-discover >=4.2.1 && <4.3,
-                       tasty-hunit,
-                       tasty-hspec,
-                       testcontainers,
-                       text
+  hs-source-dirs:     test
+  default-language:   Haskell2010
+  ghc-options:        -Wall
+  type:               exitcode-stdio-1.0
+  main-is:            Driver.hs
+  other-modules:
+    TestContainers.HspecSpec
+    TestContainers.TastySpec
+
+  build-tool-depends:
+    hspec-discover:hspec-discover, tasty-discover:tasty-discover
+
+  build-depends:
+      base
+    , hspec           >=2.0   && <3.0
+    , tasty
+    , tasty-discover  >=4.2.1 && <4.3
+    , tasty-hspec
+    , tasty-hunit
+    , testcontainers
+    , text

--- a/testcontainers.cabal
+++ b/testcontainers.cabal
@@ -27,7 +27,7 @@ library
                        TestContainers.Image
                        TestContainers.Tasty
 
-  -- other-modules:
+  other-modules:       TestContainers.AesonCompat
   -- other-extensions:
   build-depends:       base                 >=4.12 && <5,
                        aeson                >= 1.4.6 && < 3,


### PR DESCRIPTION
- Add naming strategy
- Update to lts-19.11 and dependencies
- Expose network option
- Detect a run within Docker
- Expose containerGateway
- Use ghc-9.2.4 for CI
- Aeson 2 compatibility
- Split up Monad, Config and Tracer into separate modules
