### PR TITLE
alex/ports

### DIFF
--- a/src/TestContainers.hs
+++ b/src/TestContainers.hs
@@ -29,6 +29,9 @@ module TestContainers
     M.setExpose,
     M.setWaitingFor,
 
+    -- * Port
+    M.Port (..),
+
     -- * Running Docker containers (@docker run@)
     M.Container,
     M.containerAlias,

--- a/src/TestContainers/Docker.hs
+++ b/src/TestContainers/Docker.hs
@@ -532,8 +532,7 @@ type ImageTag = Text
 --
 -- @since 0.1.0.0
 data ToImage = ToImage
-  { runToImage :: TestContainer Image,
-    applyToContainerRequest :: ContainerRequest -> ContainerRequest
+  { runToImage :: TestContainer Image
   }
 
 -- | Build the `Image` referred to by the argument. If the construction of the
@@ -543,12 +542,11 @@ data ToImage = ToImage
 --
 -- @since 0.1.0.0
 build :: ToImage -> TestContainer ToImage
-build toImage@ToImage {applyToContainerRequest} = do
+build toImage = do
   image <- runToImage toImage
   return $
-    ToImage
-      { runToImage = pure image,
-        applyToContainerRequest
+    toImage
+      { runToImage = pure image
       }
 
 -- | Default `ToImage`. Doesn't apply anything to to `ContainerRequests`.
@@ -557,8 +555,7 @@ build toImage@ToImage {applyToContainerRequest} = do
 defaultToImage :: TestContainer Image -> ToImage
 defaultToImage action =
   ToImage
-    { runToImage = action,
-      applyToContainerRequest = \x -> x
+    { runToImage = action
     }
 
 -- | Get an `Image` from a tag.

--- a/test/TestContainers/TastySpec.hs
+++ b/test/TestContainers/TastySpec.hs
@@ -56,6 +56,13 @@ containers1 = do
               waitForHttp 80 "/" [200]
           )
 
+  _jaeger <-
+    run $
+      containerRequest (fromTag "jaegertracing/all-in-one:1.6")
+        & setExpose ["5775/udp", "6831/udp", "6832/udp", "5778", "16686/tcp"]
+        & setWaitingFor
+          (waitForHttp "16686/tcp" "/" [200])
+
   _test <- run $ containerRequest (fromBuildContext "./test/container1" Nothing)
 
   pure ()


### PR DESCRIPTION
- Make WaitUntilReady a proper Semigroup and Monoid
- Use long-form argument for Docker build
- Remove obsolete applyToContainerRequest
- Allow handling ports other than tcp
