### PR TITLE
Support for GHC 9.8

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,6 +18,7 @@ jobs:
           - 9.2.8
           - 9.4.8
           - 9.6.4
+          - 9.8.2
 
     steps:
     - uses: actions/checkout@v2

--- a/src/TestContainers.hs
+++ b/src/TestContainers.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DuplicateRecordFields #-}
 -- |
 -- This module shall be used as entrypoint to the testcontainers library. It exports
 -- all the necessary types and functions for most common use-cases.


### PR DESCRIPTION
I couldn't build testcontainers (either version 0.5 or the latest version on master) due to duplicate records.

This PR uses the `DuplicateRecordField` extension to build with GHC 9.8, and also includes GHC 9.8 in the test matrix.