### PR TITLE
bump `tasty-discover` upper bound to fix Nix package

### DIFF
--- a/testcontainers.cabal
+++ b/testcontainers.cabal
@@ -84,7 +84,7 @@ test-suite tests
       base
     , hspec           >=2.0   && <3.0
     , tasty
-    , tasty-discover  >=4.2.1 && <4.3
+    , tasty-discover  >=4.2.1 && <6
     , tasty-hspec
     , tasty-hunit
     , testcontainers


### PR DESCRIPTION
```
cabal build --enable-tests --constraint 'tasty-discover==5.0.0'  -j
```
succeeds

closes: #57 

please review and publish a revision, this will eventually get into NixPkgs and fix the package there