### PR TITLE
Add `withCopyFileToContainer` to copy files to containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for testcontainer-hs
 
+## 0.5.2.0 -- Unreleased
+
+* Introduce `withCopyFileToContainer` to copy local files to the container (@LaurentRDC, https://github.com/testcontainers/testcontainers-hs/pull/62)
+
 ## 0.5.1.0 -- 2025-01-14
 
 * Introduce `withWorkingDirectory` to set the working directory inside a container (@alexbiehl, https://github.com/testcontainers/testcontainers-hs/pull/37)

--- a/src/TestContainers.hs
+++ b/src/TestContainers.hs
@@ -31,6 +31,7 @@ module TestContainers
     M.setMemory,
     M.setCpus,
     M.withWorkingDirectory,
+    M.withCopyFileToContainer,
     M.withNetwork,
     M.withNetworkAlias,
     M.setLink,

--- a/test/TestContainers/TastySpec.hs
+++ b/test/TestContainers/TastySpec.hs
@@ -27,6 +27,7 @@ import TestContainers.Tasty
     waitUntilMappedPortReachable,
     waitUntilTimeout,
     withContainers,
+    withCopyFileToContainer,
     withFollowLogs,
     withNetwork,
     (&),
@@ -77,6 +78,11 @@ containers1 = do
         & withNetwork net
         & setWaitingFor
           (waitForHttp "16686/tcp" "/" [200])
+
+  _postgres <-
+    run $
+      containerRequest (fromTag "postgres:16-alpine")
+        & withCopyFileToContainer "test/data/init-script.sql" "/docker-entrypoint-initdb.d/"
 
   _helloWorld <-
     run $

--- a/test/data/init-script.sql
+++ b/test/data/init-script.sql
@@ -1,0 +1,6 @@
+
+create table customers (
+     id bigint not null,
+     name varchar not null,
+     primary key (id)
+);

--- a/testcontainers.cabal
+++ b/testcontainers.cabal
@@ -18,6 +18,7 @@ build-type:         Simple
 extra-source-files:
   CHANGELOG.md
   README.md
+  test/data/init-script.sql
 
 tested-with:
   GHC ==8.8.4 || ==8.10.7 || ==9.0.2 || ==9.2.4 || ==9.4.2 || ==9.8.2


### PR DESCRIPTION
This PR adds a new function, `withCopyFileToContainer`, which allows to, well, copy files to a container. This is very useful, for example, when [initializing a Postgres database](https://hub.docker.com/_/postgres/#initialization-scripts).

In order to copy files to the container, the `run` function was modified to use `docker create` + `docker start` rather than `docker run`. This allows to get the container ID early (from `docker create`), and thus copy files using `docker cp` before calling `docker start`.