### PR TITLE
Update CI to use more recent cabal

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest] # [macOS-latest, windows-latest] do not come with docker :(
-        cabal: ["3.6"]
+        cabal: ["3.12.1.0"]
         ghc:
           - 9.2.8
           - 9.4.8


### PR DESCRIPTION
Ah, looks like CI failing due to https://github.com/haskell/cabal/pull/11095