### PR TITLE
Enable CI for all major platforms and highlight the broken support for Windows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest] # [macOS-latest, windows-latest] do not come with docker :(
+        os: 
+          - ubuntu-latest
+          - macos-26-intel
+          - windows-latest
         cabal: ["3.12.1.0"]
         ghc:
           - 9.2.8
@@ -45,6 +48,10 @@ jobs:
       run: |
         cabal configure -O0 --enable-tests --enable-benchmarks --test-show-details=direct
         cabal build all
+
+    - name: Set up Docker
+      if: runner.os == 'macOS'
+      uses: docker/setup-docker-action@v5
 
     - name: Test
       run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,7 @@ jobs:
     name: ${{ matrix.os }} / ghc ${{ matrix.ghc }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: 
           - ubuntu-latest


### PR DESCRIPTION
GitHub Actions now support running Docker on all major platforms. This PR enables them all and uncovers the preexisting issues on Windows (approve the workflow execution and see the run results).

The main reason is that the image of `ryuk` that the library uses (`v0.3.4`) is outdated and does not support Windows. The later releases of it do (e.g., `v0.14.0`).

However as I've already discovered trying to fix this myself, it is not only a matter of updating the image, other issues appear when it's done and I'm struggling to fix this myself since I have no experise in the library and I don't have a Windows machine.